### PR TITLE
Added commandline option to delete libraries

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -209,7 +209,8 @@ services:
 
 
 
-
+    App\Module\KirkantaEntityCommands\Command\DeleteKirkantaEntity:
+        arguments: ['@entity_type_manager']
 
     # NOTE: The built-in object normalizer has a priority -1000 so this must have a higher value.
     App\Module\ApiCache\Serializer\Normalizer\EntityNormalizer:

--- a/src/Module/KirkantaEntityCommands/Command/DeleteKirkantaEntity.php
+++ b/src/Module/KirkantaEntityCommands/Command/DeleteKirkantaEntity.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Module\KirkantaEntityCommands\Command;
+
+use App\Entity\Library;
+use App\EntityTypeManager;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class DeleteKirkantaEntity extends Command
+{
+
+    private $entityTypeManager;
+
+    public function __construct(EntityTypeManager $entityTypeManager)
+    {
+        parent::__construct();
+        
+        $this->entityTypeManager = $entityTypeManager;
+    }
+
+    protected function configure() : void
+    {
+        $this
+            ->setName('kirkanta-entity:delete')
+            ->setDescription('Delete entity with type and id')
+            ->addArgument('entity_type', InputArgument::REQUIRED, 'Entity type')
+            ->addArgument('entity_id', InputArgument::REQUIRED, 'Entity ID')
+            ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : void
+    {
+        
+        $entity_type = $input->getArgument('entity_type');
+        $entity_id = $input->getArgument('entity_id');
+
+        switch ($entity_type) {
+            case 'library':
+                $em = $this->entityTypeManager->getEntityManager();
+                $library = $em->getRepository(Library::class)
+                    ->find($entity_id);
+                if($library) {
+                    $em->remove($library);
+                    $em->flush($library);
+                } else {
+                    throw new \Exception('No library with id: ' . $entity_id);
+                }
+                break;
+
+            default:
+                throw new \Exception('Invalid entity type');
+        }
+    }
+}


### PR DESCRIPTION
- This bypasses the state awareness and deletes the library through entity
  manager.
- I tested deleting the offending library with 'bin/console kirkanta-entity:delete library 85749', re-run all the syncs and indexing, seemed to work fine after the removal.