### PR TITLE
Fixing part of the indexing issues

### DIFF
--- a/src/Module/ApiCache/Serializer/Normalizer/FinnaOrganisationNormalizer.php
+++ b/src/Module/ApiCache/Serializer/Normalizer/FinnaOrganisationNormalizer.php
@@ -51,7 +51,7 @@ class FinnaOrganisationNormalizer implements NormalizerInterface
 
             foreach ($entry['value'] as $langcode => $value) {
                 if (strlen($value) === 0) {
-                    $entry['value'][$langcode] = $fallback;
+                    $entry['value']->$langcode = $fallback;
                 }
             }
 

--- a/src/Module/ApiCache/Serializer/Normalizer/LibraryNormalizer.php
+++ b/src/Module/ApiCache/Serializer/Normalizer/LibraryNormalizer.php
@@ -112,7 +112,7 @@ class LibraryNormalizer implements NormalizerInterface
 
             foreach ($entry['value'] as $langcode => $value) {
                 if (strlen($value) === 0) {
-                    $entry['value'][$langcode] = $fallback;
+                    $entry['value']->$langcode = $fallback;
                 }
             }
 


### PR DESCRIPTION
Any changes made directly to libraries have been on hold for a while. This pull request fixes very small issue concerning the two normalizers. Should resolve part of the indexing issues we are facing. See projektit issues 5678, 5677, 5676, 5675 for more information.


Original commit:
Small Finna/LibraryNormalizer fix

Both FinnaNormalizer and LibraryNormalizer were accessing
part FinnaAdditions customData using array notation. I changed
this to object notation(back?). After this the indexing was able
to continue to certain point... Tried also modify and create
Finna organisation's additional information entities. Still worked
fine after this modification.

Feel free to revert this change if necessary, this is just a hotfix
for the indexing.