### PR TITLE
Fixed non-working delete on finna additions

### DIFF
--- a/src/Doctrine/EventListener/WeightInitializer.php
+++ b/src/Doctrine/EventListener/WeightInitializer.php
@@ -92,16 +92,24 @@ class WeightInitializer implements EventSubscriber
 
     private function loadRelatedEntities(LifecycleEventArgs $args) : ArrayCollection
     {
-        $entities = $args->getEntityManager()->createQueryBuilder()
+        $builder = $args->getEntityManager()->createQueryBuilder()
             ->select('e')
-            ->from(get_class($args->getEntity()), 'e')
-            ->where('e.parent = :library')
-            ->setParameter('library', $args->getEntity()->getParent())
-            ->orderBy('e.weight', 'desc')
-            ->indexBy('e', 'e.id')
-            ->getQuery()
-            ->getResult();
+            ->from(get_class($args->getEntity()), 'e');
+        
+        if ($args->getEntity() instanceof FinnaOrganisationWebsiteLink) {
+            $builder->where('e.id = :organisation')
+                ->setParameter('organisation', $args->getEntity()->getFinnaOrganisation());
+        } else {
+            $builder->where('e.parent = :library')
+                ->setParameter('library', $args->getEntity()->getParent());
+        }
+        
+        
+        $builder->orderBy('e.weight', 'desc')
+                ->indexBy('e', 'e.id');
 
+        $entities = $builder->getQuery()->getResult();
+        
         return new ArrayCollection($entities);
     }
 }

--- a/src/Doctrine/EventListener/WeightInitializer.php
+++ b/src/Doctrine/EventListener/WeightInitializer.php
@@ -92,18 +92,21 @@ class WeightInitializer implements EventSubscriber
 
     private function loadRelatedEntities(LifecycleEventArgs $args) : ArrayCollection
     {
+        $entity = $args->getEntity();
         $builder = $args->getEntityManager()->createQueryBuilder()
             ->select('e')
-            ->from(get_class($args->getEntity()), 'e');
+            ->from(get_class($entity), 'e');
         
-        if ($args->getEntity() instanceof FinnaOrganisationWebsiteLink) {
-            $builder->where('e.id = :organisation')
-                ->setParameter('organisation', $args->getEntity()->getFinnaOrganisation());
+        // Parent relation changes here because of the FinnaOrganisationWebsiteLink
+        // different column (finna_organisation) instead of what other ContactInfo
+        // based entitities are using (parent).
+        if ($entity instanceof FinnaOrganisationWebsiteLink) {
+            $builder->where('e.finna_organisation = :organisation')
+                ->setParameter('organisation', $entity->getFinnaOrganisation());
         } else {
             $builder->where('e.parent = :library')
-                ->setParameter('library', $args->getEntity()->getParent());
+                ->setParameter('library', $entity->getParent());
         }
-        
         
         $builder->orderBy('e.weight', 'desc')
                 ->indexBy('e', 'e.id');

--- a/src/Module/Finna/Controller/FinnaController.php
+++ b/src/Module/Finna/Controller/FinnaController.php
@@ -430,9 +430,9 @@ class FinnaController extends Controller
 
         if ($form->isSubmitted() && $form->isValid()) {
 
-            $data = $finna_organisation->getCustomData();
-            unset($data[$custom_data - 1]);
-            $finna_organisation->setCustomData($data);
+            $entries = $finna_organisation->getCustomData();
+            unset($entries[$custom_data - 1]);
+            $finna_organisation->setCustomData($entries);
 
             $this->types->getEntityManager()->flush();
             $this->addFlash('success', 'Record was deleted.');

--- a/src/Module/Finna/Controller/FinnaController.php
+++ b/src/Module/Finna/Controller/FinnaController.php
@@ -411,6 +411,48 @@ class FinnaController extends Controller
     }
 
     /**
+     * @Route("/finna_organisation/{finna_organisation}/custom-data/{custom_data}/delete", name="entity.finna_organisation.custom_data.delete")
+     * @Template("entity/FinnaAdditions/custom-data.delete.html.twig")
+     */
+    public function deleteCustomData(Request $request, FinnaAdditions $finna_organisation, int $custom_data)
+    {
+        
+        $form = $this->createFormBuilder()
+            ->add('submit', \Symfony\Component\Form\Extension\Core\Type\SubmitType::class, [
+                'label' => 'Delete',
+                'attr' => [
+                    'class' => 'btn btn-primary'
+                ]
+            ])
+            ->getForm();
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+
+            $data = $finna_organisation->getCustomData();
+            unset($data[$custom_data - 1]);
+            $finna_organisation->setCustomData($data);
+
+            $this->types->getEntityManager()->flush();
+            $this->addFlash('success', 'Record was deleted.');
+
+            return $this->redirectToRoute("entity.finna_organisation.custom_data.collection", [
+                'finna_organisation' => $finna_organisation->getId()
+            ]);
+        }
+
+        return [
+            'type_label' => 'Custom data',
+            'entity' => $finna_organisation,
+            'custom_data_pos' => $custom_data,
+            'form' => $form->createView(),
+        ];
+
+        
+    }
+
+    /**
      * @Route("/finna_organisation/{finna_organisation}/links/tablesort", name="entity.finna_organisation.table_sort")
      */
     public function tableSort(Request $request, FinnaAdditions $finna_organisation)

--- a/templates/entity/FinnaAdditions/custom-data.delete.html.twig
+++ b/templates/entity/FinnaAdditions/custom-data.delete.html.twig
@@ -1,0 +1,14 @@
+{% extends "entity/delete.html.twig" %}
+
+{% block title_text %}
+  {% trans with {"%type%": "Custom data"|trans|lower, "%id%": custom_data_pos} %}Delete %type% #%id%{% endtrans %}
+{% endblock %}
+
+{% block delete_button_outer %}
+  {% set entity_delete_url = path("entity.%s.custom_data.delete"|format(entity_type), {
+    (entity_type): entity.id,
+    custom_data: custom_data_pos
+  }) %}
+
+  {{ block("delete_button") }}
+{% endblock %}

--- a/templates/entity/FinnaAdditions/custom-data.edit.html.twig
+++ b/templates/entity/FinnaAdditions/custom-data.edit.html.twig
@@ -1,5 +1,18 @@
 {% extends "entity/edit.html.twig" %}
 
+{% form_theme form _self %}
+
+{% block delete_button_outer %}
+  {% if custom_data_pos is defined %}
+    {% set entity_delete_url = path("entity.%s.custom_data.delete"|format(entity_type), {
+      (entity_type): entity.id,
+      custom_data: custom_data_pos
+    }) %}
+
+    {{ block("delete_button") }}
+  {% endif %}
+{% endblock %}
+
 {% block form_header %}
   {{ parent() }}
 


### PR DESCRIPTION
When trying to delete customdata from finna organisation, it would result on attempt to delete the finna organisation itself (By attempt, I mean it failed). Now fixed in this pull request.
Also deleting weblinks from finna organisation was not working (something to do with the Weight's). Now they work, but after deleting  a link, you are redirected to the global weblink listing? (still needs some work)