### PR TITLE
Fix for the disappearing customdata values

### DIFF
--- a/public/dist/style.css
+++ b/public/dist/style.css
@@ -7815,8 +7815,7 @@ form.period_form .fa-plus-circle {
   color: green; }
 
 form.period_form fieldset.period-schedules {
-  background-color: rgba(0, 0, 0, 0.05);
-  overflow: hidden; }
+  background-color: rgba(0, 0, 0, 0.05); }
   form.period_form fieldset.period-schedules > .container-fluid {
     padding: 2rem 0 0;
     margin: -37px 0 0; }

--- a/public/scss/_entity.period.scss
+++ b/public/scss/_entity.period.scss
@@ -20,7 +20,6 @@ form.period_form {
   fieldset.period-schedules {
     // font-size: large;
     background-color: $table-accent-bg;
-    overflow: hidden;
 
     > .container-fluid {
       padding: (2 * $spacer) 0 0;

--- a/src/Module/ApiCache/Serializer/Normalizer/FinnaOrganisationNormalizer.php
+++ b/src/Module/ApiCache/Serializer/Normalizer/FinnaOrganisationNormalizer.php
@@ -55,6 +55,10 @@ class FinnaOrganisationNormalizer implements NormalizerInterface
                 }
             }
 
+            // Cast to associative array for serialization
+            $entry['value'] = (array) $entry['value'];
+            $entry['title'] = (array) $entry['title'];
+
             $entries[] = $entry;
         }
 

--- a/src/Module/ApiCache/Serializer/Normalizer/LibraryNormalizer.php
+++ b/src/Module/ApiCache/Serializer/Normalizer/LibraryNormalizer.php
@@ -116,6 +116,10 @@ class LibraryNormalizer implements NormalizerInterface
                 }
             }
 
+            // Cast to associative array for serialization
+            $entry['value'] = (array) $entry['value'];
+            $entry['title'] = (array) $entry['title'];
+
             $entries[] = $entry;
         }
 

--- a/src/Module/KirkantaEntityCommands/Command/DeleteKirkantaEntity.php
+++ b/src/Module/KirkantaEntityCommands/Command/DeleteKirkantaEntity.php
@@ -3,6 +3,8 @@
 namespace App\Module\KirkantaEntityCommands\Command;
 
 use App\Entity\Library;
+use App\Entity\Organisation;
+use App\Entity\ServicePoint;
 use App\EntityTypeManager;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,13 +42,24 @@ class DeleteKirkantaEntity extends Command
         switch ($entity_type) {
             case 'library':
                 $em = $this->entityTypeManager->getEntityManager();
-                $library = $em->getRepository(Library::class)
+                $entity = $em->getRepository(Library::class)
                     ->find($entity_id);
-                if($library) {
-                    $em->remove($library);
-                    $em->flush($library);
+                if($entity) {
+                    $em->remove($entity);
+                    $em->flush($entity);
                 } else {
                     throw new \Exception('No library with id: ' . $entity_id);
+                }
+                break;
+            case 'service_point':
+                $em = $this->entityTypeManager->getEntityManager();
+                $entity = $em->getRepository(ServicePoint::class)
+                    ->find($entity_id);
+                if($entity) {
+                    $em->remove($entity);
+                    $em->flush($entity);
+                } else {
+                    throw new \Exception('No service point with id: ' . $entity_id);
                 }
                 break;
 


### PR DESCRIPTION
Fix for Custom Data not being indexed correctly
- Custom data 'value' and 'title' fields did not get indexed correctly.
  Force casting them from object to associative array fixes the issue.
  This has something to do how symfony/php handles the json
  serialization of nested objects.
Added additional entity type for cli deletion
Fix usability issue with schedule time selector
