### PR TITLE
Fix kirkanta contact export

### DIFF
--- a/src/Module/ExportLibraryContactInfo/Controller/ExportController.php
+++ b/src/Module/ExportLibraryContactInfo/Controller/ExportController.php
@@ -110,7 +110,7 @@ class ExportController extends Controller
             $lastModified = max($lastModified, $lmod);
 
             if ($values->group) {
-                if ($lastCity != $library->getCity()) {
+                if (is_null($lastCity) || $lastCity->getId() !== $library->getCity()->getId()) {
                     if ($lastCity) {
                         $export[] = [];
                     }


### PR DESCRIPTION
Recursion occurs when comparing cities with non-strict comparison operator. Switching to compare with cities id's will prevent recursion error happening.