### PR TITLE
Reset days info language to match period's language

### DIFF
--- a/src/Form/PeriodForm.php
+++ b/src/Form/PeriodForm.php
@@ -121,7 +121,7 @@ class PeriodForm extends EntityFormType
             }
         });
 
-        // Days info language needs to be reset to match the period. 
+        // Days info language needs to be reset to match the period.
         $builder->addEventListener(FormEvents::SUBMIT, function (FormEvent $event) {
             $period = $event->getData();
             $form = $event->getForm();

--- a/src/Form/PeriodForm.php
+++ b/src/Form/PeriodForm.php
@@ -137,7 +137,7 @@ class PeriodForm extends EntityFormType
                 // temporary language code 'xx' inherited from the period.
                 // Only when the form is submitted, does the correct language code
                 // get populated. Hence, this fix is done in the submit handler and
-                // the correct languade code is added in the day object.
+                // the correct language code is added in the day object.
                 foreach ($days as $key => $day) {
                     if(array_key_exists($temp_lang, $day['info'])) {
                         $days[$key]['info'][$langcode] = $day['info'][$temp_lang];

--- a/src/Form/PeriodForm.php
+++ b/src/Form/PeriodForm.php
@@ -133,7 +133,7 @@ class PeriodForm extends EntityFormType
 
                 // When creating a new period, depending on the context, the period's
                 // language is not known when form is created. This creates problem with
-                // the period's nested day forms, since they are keyed with the 
+                // the period's nested day forms, since they are keyed with the
                 // temporary language code 'xx' inherited from the period.
                 // Only when the form is submitted, does the correct language code
                 // get populated. Hence, this fix is done in the submit handler and


### PR DESCRIPTION
This should fix the following issue with using the period templates:
When creating a period template, the content language selected does not get passed to days info field. Instead the temporary language code ('xx') is assigned to info fields. This creates a problem with api when serving schedules created from the templates. Instead returning plain string in "info" property, a object with single key "xx" is returned. This happens because api does not handle 'xx' as supported language (rightly so).
Here is the incorrect api v4 schedule output:
```
{
    "library": 85345,
    "period": 344115,
    "date": "2020-06-20",
    "info": {
        "xx": null
    },
    "closed": true,
    "times": []
}
```
The fix itself just adds extra submit handler for making sure that the localization is passed to the days->info fields. This fix only targets newly created period templates and does not affect existing ones. For that I have to run the following snippet:
https://gist.github.com/humble-ahitofel/b952c0143070023bf1a28f32dc18a4b7
The snippet above adds an empty field with the default language acting as key to every(expect legacy) period's day info field.

The original issue: https://projektit.kirjastot.fi/issues/5815?next_issue_id=5814