### PR TITLE
Fix for the 'not null' violation when adding a new postal address to existing library

### DIFF
--- a/src/Form/LibraryForm.php
+++ b/src/Form/LibraryForm.php
@@ -175,6 +175,12 @@ class LibraryForm extends EntityFormType
                 if ($address = $data->getMailAddress()) {
                     FormData::persistTemporaryTranslation($address->getTranslations(), $langcode);
                 }
+            } else {
+                $mail_address = $data->getMailAddress();
+
+                if($mail_address && !$mail_address->getDefaultLangcode()) {
+                    $mail_address->setDefaultLangcode($data->getDefaultLangcode());
+                }
             }
         });
     }


### PR DESCRIPTION
When adding new postal address to the existing library, it will cause a 'not null' error with the default language code field. However, this does not happen when creating a new library entry with postal address. The problem occurs only when adding postal address to a pre-existing library.

The original issue: https://projektit.kirjastot.fi/issues/5824