### PR TITLE
Revert UserGroupForm parent class to FormType

### DIFF
--- a/src/Form/UserGroupForm.php
+++ b/src/Form/UserGroupForm.php
@@ -8,11 +8,10 @@ use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-class UserGroupForm extends EntityFormType
+class UserGroupForm extends FormType
 {
     public function form(FormBuilderInterface $builder, array $options) : void
     {
-        parent::form($builder, $options);
 
         $builder
             ->add('name')


### PR DESCRIPTION
Currently creation of new UserGroup is not working:
 https://projektit.kirjastot.fi/issues/5844

Commit message:
UserGroup entity does not have any language support currently
implemented. EntityFormType class presumes that the current Entity is
translatable, but when trying to create a new group will result in an
error.
The easiest non-rippling fix here is to revert to the older FormType
parent class. This might be reverted in the future if UserGroup is made
translatable or EntityFormType will have support for non-translatable
entities.