### PR TITLE
Fix a not-null constrain error when adding new service point

### DIFF
--- a/src/Entity/Library.php
+++ b/src/Entity/Library.php
@@ -87,16 +87,4 @@ class Library extends Facility implements LibraryInterface
         $this->main_library = $state;
     }
 
-    public function setDefaultLangcode(string $langcode) : void
-    {
-        parent::setDefaultLangcode($langcode);
-
-        if ($addr = $this->getAddress()) {
-            $addr->setDefaultLangcode($langcode);
-        }
-
-        if ($addr = $this->getMailAddress()) {
-            $addr->setDefaultLangcode($langcode);
-        }
-    }
 }

--- a/src/Entity/LibraryTrait.php
+++ b/src/Entity/LibraryTrait.php
@@ -432,4 +432,20 @@ trait LibraryTrait
             'regional',
         ]);
     }
+
+    /**
+     * Set default language code and also set it for all contained addresses.
+     */
+    public function setDefaultLangcode(string $langcode) : void
+    {
+        parent::setDefaultLangcode($langcode);
+
+        if ($addr = $this->getAddress()) {
+            $addr->setDefaultLangcode($langcode);
+        }
+
+        if ($addr = $this->getMailAddress()) {
+            $addr->setDefaultLangcode($langcode);
+        }
+    }
 }


### PR DESCRIPTION
This is done by moving the 'setDefaultLangcode' from Library to LibraryTrait. Both Library and ServicePoint use the LibraryTrait so it will fix the issue described here:
https://projektit.kirjastot.fi/issues/5853

Commit message:
Move settings default language code to LIbraryTrait

Fix a not-null constrain error when adding new service point.