### PR TITLE
Show Finna organisations without service point

### DIFF
--- a/src/Module/Finna/Entity/ListBuilder/FinnaAdditionsListBuilder.php
+++ b/src/Module/Finna/Entity/ListBuilder/FinnaAdditionsListBuilder.php
@@ -16,7 +16,7 @@ class FinnaAdditionsListBuilder extends EntityListBuilder
             ->addSelect('ug')
             ->join('e.consortium', 'c')
             ->join('c.translations', 'cd', 'WITH', 'cd.langcode = e.default_langcode')
-            ->join('e.service_point', 'sp')
+            ->leftJoin('e.service_point', 'sp')
             ->join('e.group', 'ug')
             ->andWhere('c.state >= 0')
             ;


### PR DESCRIPTION
Previously if no service point was assigned to Finna organisation, then
the organisation would not be visible in the administration listings.
Fixed by changing the join type in listing query.

I'm referring the listing in `/finna_organisation`:
![finna-listing](https://user-images.githubusercontent.com/5386595/97555296-a0701200-19e0-11eb-901e-c27ff07927ee.png)
