### PR TITLE
Set default language code on new addresses

### DIFF
--- a/src/Form/LibraryForm.php
+++ b/src/Form/LibraryForm.php
@@ -210,6 +210,15 @@ class LibraryForm extends EntityFormType
                     FormData::persistTemporaryTranslation($address->getTranslations(), $langcode);
                 }
             } else {
+                // Rarely an existing library without an address is found. If
+                // this is the case then the default language code needs to be
+                // set from the library otherwise the address insertion will fail.
+                $address = $data->getAddress();
+
+                if($address && !$address->getDefaultLangcode()) {
+                    $address->setDefaultLangcode($data->getDefaultLangcode());
+                }
+
                 $mail_address = $data->getMailAddress();
 
                 if($mail_address && !$mail_address->getDefaultLangcode()) {


### PR DESCRIPTION
When adding a new address to an existing library, the submission fails
because of the missing language code. This commit remedies that.

Resolves issues:
https://projektit.kirjastot.fi/issues/5992
https://projektit.kirjastot.fi/issues/5712