### PR TITLE
Fix City Update Issue in Library

### DIFF
--- a/src/Form/LibraryForm.php
+++ b/src/Form/LibraryForm.php
@@ -211,7 +211,12 @@ class LibraryForm extends EntityFormType
                     FormData::persistTemporaryTranslation($address->getTranslations(), $langcode);
                 }
             } else {
+                $address = $data->getAddress();
                 $mail_address = $data->getMailAddress();
+
+                if ($address && $address->getCity()) {
+                    $data->setCity($address->getCity());
+                }
 
                 if($mail_address && !$mail_address->getDefaultLangcode()) {
                     $mail_address->setDefaultLangcode($data->getDefaultLangcode());


### PR DESCRIPTION
The city change in library's address is not reflecting in the library's own table. This fix passes on the updated city data from the address to the library table.