### PR TITLE
Flatten service template list in ServiceInstanceForm for strict alphabetical ordering

### DIFF
--- a/src/Form/ServiceInstanceForm.php
+++ b/src/Form/ServiceInstanceForm.php
@@ -33,7 +33,6 @@ class ServiceInstanceForm extends EntityFormType
                 'class' => Service::class,
                 'placeholder' => '-- Select --',
                 'choice_label' => 'name',
-                'group_by' => 'type',
             ])
             ->add('for_loan', CheckboxType::class, [
                 'required' => false,


### PR DESCRIPTION
Done by removing the grouping altogether from the service template selector (it was just for visual representation and does not affect functionality).